### PR TITLE
Fix constant name typo

### DIFF
--- a/src/langs.rs
+++ b/src/langs.rs
@@ -8,7 +8,7 @@ pub struct Language {
     pub expression_writer: r42t::Writer,
 }
 
-pub const LENGUAGES: [Language; 5] = [
+pub const LANGUAGES: [Language; 5] = [
     Language {name: "Rust", extension: "rs", template_writer: rust_template_writer, expression_writer: rust_expression_writer},
     Language {name: "C#", extension: "cs", template_writer: csharp_template_writer, expression_writer: csharp_expression_writer},
     Language {name: "Java", extension: "java", template_writer: java_template_writer, expression_writer: java_expression_writer},

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ fn print_help() {
 
     println!("Usage: r42 [Language/Glob]");
     println!("  Language: (using stdio)");
-    for l in langs::LENGUAGES {
+    for l in langs::LANGUAGES {
         println!("    r42 {:?}", l.name);
     }
     println!("  Glob: (using filesystem, files like 'file.rs.r42')");
@@ -54,7 +54,7 @@ fn handle_file(template_path: &PathBuf) {
         },
     };
 
-    let lang = match langs::LENGUAGES.iter().filter(|l| l.extension == extension.to_string()).nth(0) {
+    let lang = match langs::LANGUAGES.iter().filter(|l| l.extension == extension.to_string()).nth(0) {
         Some(l) => l,
         None => {
             println!("No language found for extension {:?}", extension);
@@ -107,7 +107,7 @@ fn main() {
 
     let args: Vec<String> = ::std::env::args().collect();
 
-    let lang = &langs::LENGUAGES[0];
+    let lang = &langs::LANGUAGES[0];
 
     if args.len() < 2 {
         use_stdio(&lang);
@@ -115,7 +115,7 @@ fn main() {
         if args[1] == "--help" {
             print_help();
         } else {
-            match langs::LENGUAGES.iter().filter(|l| l.name == &args[1]).nth(0) {
+            match langs::LANGUAGES.iter().filter(|l| l.name == &args[1]).nth(0) {
                 Some(l) => { use_stdio(&l) },
                 None => { use_glob(&args[1]);},
             }


### PR DESCRIPTION
## Summary
- rename `LENGUAGES` constant to `LANGUAGES`
- update all usages of the constant

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_684a0074c5388323bdf20d7d37ff46f1